### PR TITLE
Fix mobile chat visibility issue

### DIFF
--- a/js/assistant-frontend.js
+++ b/js/assistant-frontend.js
@@ -20,7 +20,7 @@ jQuery(function($){
       }).fail(function(){
         msgs.append('<div class="msg error">Error al enviar</div>');
       });
-      w[0].scrollTop = w[0].scrollHeight;
+      msgs[0].scrollTop = msgs[0].scrollHeight;
     }
     w.find('.oa-form').on('submit', function(e){e.preventDefault(); sendMessage(input.val().trim());});
     input.on('keypress', function(e){ if(e.which===13){e.preventDefault(); sendMessage(input.val().trim());}});

--- a/js/assistant.js
+++ b/js/assistant.js
@@ -1,2 +1,2 @@
-// Admin JS for OpenAI Assistant v2.9.19
-jQuery(()=>console.log('OA Admin loaded v2.9.19'));
+// Admin JS for OpenAI Assistant v2.9.20
+jQuery(()=>console.log('OA Admin loaded v2.9.20'));

--- a/openai-assistant.php
+++ b/openai-assistant.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: OpenAI Assistant
 Description: Embed OpenAI Assistants via shortcode.
-Version: 2.9.19
+Version: 2.9.20
 Author: Tangible Data
 Text Domain: oa-assistant
 */
@@ -115,13 +115,13 @@ class OA_Assistant_Plugin {
 
     public function enqueue_admin_assets($hook) {
         if ($hook !== 'toplevel_page_oa-assistant') return;
-        wp_enqueue_style('oa-admin-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.19');
-        wp_enqueue_script('oa-admin-js', plugin_dir_url(__FILE__).'js/assistant.js', ['jquery'], '2.9.19', true);
+        wp_enqueue_style('oa-admin-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.20');
+        wp_enqueue_script('oa-admin-js', plugin_dir_url(__FILE__).'js/assistant.js', ['jquery'], '2.9.20', true);
     }
 
     public function enqueue_frontend_assets() {
-        wp_enqueue_style('oa-frontend-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.19');
-        wp_enqueue_script('oa-frontend-js', plugin_dir_url(__FILE__).'js/assistant-frontend.js', ['jquery'], '2.9.19', true);
+        wp_enqueue_style('oa-frontend-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.20');
+        wp_enqueue_script('oa-frontend-js', plugin_dir_url(__FILE__).'js/assistant-frontend.js', ['jquery'], '2.9.20', true);
     }
 
     public function register_shortcodes() {


### PR DESCRIPTION
## Summary
- ensure chat scrolls to the latest message so text is visible on mobile
- bump plugin version to 2.9.20

## Testing
- `php -l openai-assistant.php`
- `node --check js/assistant-frontend.js`
- `node --check js/assistant.js`


------
https://chatgpt.com/codex/tasks/task_e_68841e2ddc9c83329877ddce543d42a2