### PR TITLE
Add AMP iframe fallback for mobile plugin usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ This plugin allows embedding OpenAI Assistants via a shortcode.
 - `css/assistant.css` – plugin styles.
 - `js/assistant.js` – admin scripts.
 - `js/assistant-frontend.js` – frontend scripts.
+
+## AMP/mobile support
+
+When the shortcode is used inside an AMP page, the plugin now embeds the chat in
+an `amp-iframe`. The iframe loads a non-AMP version of the chat so the full
+JavaScript functionality works on mobile devices. No configuration is required.

--- a/js/assistant.js
+++ b/js/assistant.js
@@ -1,2 +1,2 @@
-// Admin JS for OpenAI Assistant v2.9.20
-jQuery(()=>console.log('OA Admin loaded v2.9.20'));
+// Admin JS for OpenAI Assistant v2.9.21
+jQuery(()=>console.log('OA Admin loaded v2.9.21'));


### PR DESCRIPTION
## Summary
- enable AMP/mobile access for the assistant
- implement `amp-iframe` fallback in shortcode
- add query var endpoint to serve chat iframe
- bump version to 2.9.21 and update admin JS
- document AMP/mobile support in README

## Testing
- `php -l openai-assistant.php`

------
https://chatgpt.com/codex/tasks/task_e_6884313e6bdc8332b4e6c46daef46e13