### PR TITLE
Fix responsive chat iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,6 @@ This plugin allows embedding OpenAI Assistants via a shortcode.
 
 When the shortcode is used inside an AMP page, the plugin now embeds the chat in
 an `amp-iframe`. The iframe loads a non-AMP version of the chat so the full
-JavaScript functionality works on mobile devices. No configuration is required.
+JavaScript functionality works on mobile devices. The iframe now uses a
+`responsive` layout so it adapts to smaller screens. No configuration is
+required.

--- a/css/assistant.css
+++ b/css/assistant.css
@@ -1,4 +1,4 @@
-.oa-assistant-chat{border:1px solid #ddd;padding:10px;max-width:400px;}
+.oa-assistant-chat{border:1px solid #ddd;padding:10px;max-width:400px;width:100%;box-sizing:border-box;}
 .oa-messages{height:200px;overflow-y:auto;margin-bottom:10px;}
 .msg.user{text-align:right;}
 .msg.bot{text-align:left;}

--- a/js/assistant.js
+++ b/js/assistant.js
@@ -1,2 +1,2 @@
-// Admin JS for OpenAI Assistant v2.9.21
-jQuery(()=>console.log('OA Admin loaded v2.9.21'));
+// Admin JS for OpenAI Assistant v2.9.22
+jQuery(()=>console.log('OA Admin loaded v2.9.22'));

--- a/openai-assistant.php
+++ b/openai-assistant.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: OpenAI Assistant
 Description: Embed OpenAI Assistants via shortcode.
-Version: 2.9.21
+Version: 2.9.22
 Author: Tangible Data
 Text Domain: oa-assistant
 */
@@ -117,13 +117,13 @@ class OA_Assistant_Plugin {
 
     public function enqueue_admin_assets($hook) {
         if ($hook !== 'toplevel_page_oa-assistant') return;
-        wp_enqueue_style('oa-admin-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.21');
-        wp_enqueue_script('oa-admin-js', plugin_dir_url(__FILE__).'js/assistant.js', ['jquery'], '2.9.21', true);
+        wp_enqueue_style('oa-admin-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.22');
+        wp_enqueue_script('oa-admin-js', plugin_dir_url(__FILE__).'js/assistant.js', ['jquery'], '2.9.22', true);
     }
 
     public function enqueue_frontend_assets() {
-        wp_enqueue_style('oa-frontend-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.21');
-        wp_enqueue_script('oa-frontend-js', plugin_dir_url(__FILE__).'js/assistant-frontend.js', ['jquery'], '2.9.21', true);
+        wp_enqueue_style('oa-frontend-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.22');
+        wp_enqueue_script('oa-frontend-js', plugin_dir_url(__FILE__).'js/assistant-frontend.js', ['jquery'], '2.9.22', true);
     }
 
     public function register_shortcodes() {
@@ -177,7 +177,7 @@ class OA_Assistant_Plugin {
                 'oa_assistant_slug'  => $c['slug'],
             ], home_url('/'));
             return sprintf(
-                '<amp-iframe width="400" height="320" layout="fixed-height" sandbox="allow-scripts allow-same-origin" frameborder="0" src="%s"></amp-iframe>',
+                '<amp-iframe width="400" height="320" layout="responsive" sandbox="allow-scripts allow-same-origin" frameborder="0" src="%s"></amp-iframe>',
                 esc_url($src)
             );
         }


### PR DESCRIPTION
## Summary
- improve mobile support with responsive AMP iframe
- set chat container width to 100%
- bump version to 2.9.22

## Testing
- `php -l openai-assistant.php`

------
https://chatgpt.com/codex/tasks/task_e_6884338982f083329eeaff294138690b