### PR TITLE
Disable AMP iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ This plugin allows embedding OpenAI Assistants via a shortcode.
 
 ## AMP/mobile support
 
-When the shortcode is used inside an AMP page, the plugin embeds the chat in an
-`amp-iframe`. The iframe loads a non-AMP version of the chat so the full
-JavaScript functionality works on mobile devices. The iframe now uses a
-`responsive` layout so it adapts to smaller screens and includes the
-`allow-forms` sandbox permission so the chat input works correctly. No
-configuration is required.
+The plugin no longer embeds the chat in an `amp-iframe`. If you need to use the
+shortcode on a page that is served as AMP, disable the AMP version of that page
+so the normal responsive layout loads. This ensures the chat works correctly on
+mobile devices.

--- a/js/assistant.js
+++ b/js/assistant.js
@@ -1,2 +1,2 @@
-// Admin JS for OpenAI Assistant v2.9.23
-jQuery(()=>console.log('OA Admin loaded v2.9.23'));
+// Admin JS for OpenAI Assistant v2.9.24
+jQuery(()=>console.log('OA Admin loaded v2.9.24'));

--- a/openai-assistant.php
+++ b/openai-assistant.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: OpenAI Assistant
 Description: Embed OpenAI Assistants via shortcode.
-Version: 2.9.23
+Version: 2.9.24
 Author: Tangible Data
 Text Domain: oa-assistant
 */
@@ -117,13 +117,13 @@ class OA_Assistant_Plugin {
 
     public function enqueue_admin_assets($hook) {
         if ($hook !== 'toplevel_page_oa-assistant') return;
-        wp_enqueue_style('oa-admin-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.23');
-        wp_enqueue_script('oa-admin-js', plugin_dir_url(__FILE__).'js/assistant.js', ['jquery'], '2.9.23', true);
+        wp_enqueue_style('oa-admin-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.24');
+        wp_enqueue_script('oa-admin-js', plugin_dir_url(__FILE__).'js/assistant.js', ['jquery'], '2.9.24', true);
     }
 
     public function enqueue_frontend_assets() {
-        wp_enqueue_style('oa-frontend-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.23');
-        wp_enqueue_script('oa-frontend-js', plugin_dir_url(__FILE__).'js/assistant-frontend.js', ['jquery'], '2.9.23', true);
+        wp_enqueue_style('oa-frontend-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.24');
+        wp_enqueue_script('oa-frontend-js', plugin_dir_url(__FILE__).'js/assistant-frontend.js', ['jquery'], '2.9.24', true);
     }
 
     public function register_shortcodes() {
@@ -171,16 +171,6 @@ class OA_Assistant_Plugin {
         }
         $c = array_pop($cfgs);
 
-        if (function_exists('is_amp_endpoint') && is_amp_endpoint()) {
-            $src = add_query_arg([
-                'oa_assistant_embed' => '1',
-                'oa_assistant_slug'  => $c['slug'],
-            ], home_url('/'));
-            return sprintf(
-                '<amp-iframe width="400" height="320" layout="responsive" sandbox="allow-scripts allow-same-origin allow-forms" frameborder="0" src="%s"></amp-iframe>',
-                esc_url($src)
-            );
-        }
 
         $ajax_url = esc_attr(admin_url('admin-ajax.php'));
         $nonce    = esc_attr(wp_create_nonce('oa_assistant_chat'));


### PR DESCRIPTION
## Summary
- disable AMP iframe fallback
- document that AMP pages should be disabled for the shortcode
- bump plugin version to 2.9.24

## Testing
- `php -l openai-assistant.php`

------
https://chatgpt.com/codex/tasks/task_e_688436f738f883329878fdf6df2e83dd