### PR TITLE
Implement API key recovery

### DIFF
--- a/js/assistant.js
+++ b/js/assistant.js
@@ -23,4 +23,22 @@ jQuery(function($){
     e.preventDefault();
     $(this).closest('tr').remove();
   });
+
+  $('.oa-recover-key').on('click', function(e){
+    e.preventDefault();
+    $.ajax({
+      url: oaAssistant.ajax_url,
+      method: 'POST',
+      dataType: 'json',
+      data: {
+        action: 'oa_assistant_send_key',
+        nonce: oaAssistant.nonce
+      }
+    }).done(function(res){
+      alert(res.success ? 'Email enviado' : 'Error: ' + res.data);
+    }).fail(function(xhr){
+      var msg = xhr.responseJSON && xhr.responseJSON.data ? xhr.responseJSON.data : 'Error al enviar';
+      alert(msg);
+    });
+  });
 });

--- a/openai-assistant.php
+++ b/openai-assistant.php
@@ -18,6 +18,7 @@ class OA_Assistant_Plugin {
         add_action('wp_enqueue_scripts', [$this, 'enqueue_frontend_assets']);
         add_action('wp_ajax_oa_assistant_chat', [$this, 'ajax_chat']);
         add_action('wp_ajax_nopriv_oa_assistant_chat', [$this, 'ajax_chat']);
+        add_action('wp_ajax_oa_assistant_send_key', [$this, 'ajax_send_key']);
         add_filter('query_vars', [$this, 'register_query_vars']);
         add_action('template_redirect', [$this, 'maybe_render_embed']);
     }
@@ -104,7 +105,9 @@ class OA_Assistant_Plugin {
             echo '<p>Tu clave secreta de OpenAI.</p>';
         }, 'oa-assistant-general');
         add_settings_field('oa_assistant_api_key', 'OpenAI API Key', function(){
-            printf('<input type="password" id="oa_assistant_api_key" name="oa_assistant_api_key" value="%s" class="regular-text" />', esc_attr(get_option('oa_assistant_api_key','')));
+            $val = esc_attr(get_option('oa_assistant_api_key', ''));
+            echo '<input type="password" id="oa_assistant_api_key" name="oa_assistant_api_key" value="'.$val.'" class="regular-text" /> ';
+            echo '<button type="button" class="button oa-recover-key">'.esc_html__('Recuperar', 'oa-assistant').'</button>';
         }, 'oa-assistant-general', 'oa-assistant-api-section');
 
         register_setting('oa-assistant-configs', 'oa_assistant_configs', [
@@ -134,6 +137,10 @@ class OA_Assistant_Plugin {
         if ($hook !== 'toplevel_page_oa-assistant') return;
         wp_enqueue_style('oa-admin-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '2.9.25');
         wp_enqueue_script('oa-admin-js', plugin_dir_url(__FILE__).'js/assistant.js', ['jquery'], '2.9.25', true);
+        wp_localize_script('oa-admin-js', 'oaAssistant', [
+            'ajax_url' => admin_url('admin-ajax.php'),
+            'nonce'    => wp_create_nonce('oa_assistant_send_key'),
+        ]);
     }
 
     public function enqueue_frontend_assets() {
@@ -264,6 +271,23 @@ class OA_Assistant_Plugin {
         }
 
         wp_send_json_success(['reply' => $reply]);
+    }
+
+    public function ajax_send_key() {
+        check_ajax_referer('oa_assistant_send_key', 'nonce');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('Unauthorized', 403);
+        }
+        $key = get_option('oa_assistant_api_key', '');
+        if (!$key) {
+            wp_send_json_error('No API key');
+        }
+        $sent = wp_mail(get_option('admin_email'), 'OpenAI Assistant API Key', 'Tu API Key: ' . $key);
+        if ($sent) {
+            wp_send_json_success('Email enviado');
+        } else {
+            wp_send_json_error('No se pudo enviar el email', 500);
+        }
     }
 
     // Placeholder: implement your vector DB retrieval logic


### PR DESCRIPTION
## Summary
- add AJAX handler `oa_assistant_send_key`
- localize admin script with nonce
- add recovery button and JS to send AJAX request
- improve error reporting when sending the key

## Testing
- `php -l openai-assistant.php`
- `node -c js/assistant.js`


------
https://chatgpt.com/codex/tasks/task_e_6884bb6c2ac083329c0f2993e7e29f47