### PR TITLE
Implement API key recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 This plugin allows embedding OpenAI Assistants via a shortcode.
 
 The administration page lets you manage multiple assistants. You can add new
-rows for assistants or remove existing ones before saving the settings.
+rows for assistants or remove existing ones before saving the settings. It also
+includes a recovery button that emails the stored API key to the site admin in
+case you forget it.
 
 ## File structure
 

--- a/js/assistant.js
+++ b/js/assistant.js
@@ -23,4 +23,22 @@ jQuery(function($){
     e.preventDefault();
     $(this).closest('tr').remove();
   });
+
+  $('.oa-recover-key').on('click', function(e){
+    e.preventDefault();
+    $.ajax({
+      url: oaAssistant.ajax_url,
+      method: 'POST',
+      dataType: 'json',
+      data: {
+        action: 'oa_assistant_send_key',
+        nonce: oaAssistant.nonce
+      }
+    }).done(function(res){
+      alert(res.success ? 'Email enviado' : 'Error: ' + res.data);
+    }).fail(function(xhr){
+      var msg = xhr.responseJSON && xhr.responseJSON.data ? xhr.responseJSON.data : 'Error al enviar';
+      alert(msg);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add AJAX handler `oa_assistant_send_key`
- localize admin script with nonce
- add recovery button and JS to send AJAX request
- improve error reporting when sending the key
- localize email subject and body

## Testing
- `php -l openai-assistant.php`
- `node --check js/assistant.js`


------
https://chatgpt.com/codex/tasks/task_e_6884bb6c2ac083329c0f2993e7e29f47