### PR TITLE
Improve admin table responsiveness

### DIFF
--- a/css/assistant.css
+++ b/css/assistant.css
@@ -4,3 +4,5 @@
 .msg.bot{text-align:left;}
 .oa-form input{width:70%;}
 .oa-remove-assistant{color:#a00;}
+.oa-table-wrap{overflow-x:auto;}
+.oa-assistants-table{min-width:600px;width:100%;}

--- a/openai-assistant.php
+++ b/openai-assistant.php
@@ -46,6 +46,7 @@ class OA_Assistant_Plugin {
                 settings_fields('oa-assistant-configs');
                 $configs = get_option('oa_assistant_configs', []);
                 ?>
+                <div class="oa-table-wrap">
                 <table class="widefat oa-assistants-table">
                     <thead>
                         <tr>
@@ -76,6 +77,7 @@ class OA_Assistant_Plugin {
                         <?php endif; ?>
                     </tbody>
                 </table>
+                </div>
                 <script type="text/html" id="oa-row-template">
                     <tr data-index="__i__">
                         <td><input type="text" name="oa_assistant_configs[__i__][nombre]" class="regular-text" /></td>


### PR DESCRIPTION
## Summary
- wrap admin assistants table with a scrollable container
- add CSS rules for responsive admin view

## Testing
- `php -l openai-assistant.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6886b0b488cc8332b13df1fba90f4433