### PR TITLE
Improve slug usability

### DIFF
--- a/css/assistant.css
+++ b/css/assistant.css
@@ -9,3 +9,5 @@
 .oa-assistants-table{min-width:600px;width:100%;}
 .oa-existing-assistants{margin-top:10px;}
 .oa-old-field input,.oa-old-field textarea{background-color:#f7f7f7;color:#777;}
+.oa-slug-field{width:220px;margin-right:4px;}
+.oa-copy-slug{vertical-align:middle;}

--- a/js/assistant.js
+++ b/js/assistant.js
@@ -11,4 +11,24 @@ jQuery(function($){
       alert('Error al enviar');
     });
   });
+
+  function slugify(text){
+    return text.toString().toLowerCase().trim()
+      .replace(/[^\w\- ]+/g,'')
+      .replace(/\s+/g,'-');
+  }
+  var slugInput = $('#oa_slug');
+  $('#oa_name').on('input', function(){
+    if(!slugInput.val()){
+      slugInput.val(slugify($(this).val()));
+    }
+  });
+
+  $('.oa-copy-slug').on('click', function(){
+    var text = $(this).data('slug');
+    if(!text) return;
+    navigator.clipboard.writeText(text).then(function(){
+      alert('Copiado');
+    });
+  });
 });

--- a/openai-assistant.php
+++ b/openai-assistant.php
@@ -68,7 +68,10 @@ class OA_Assistant_Plugin {
                             foreach ($list as $slug => $a) : ?>
                         <tr>
                             <td><?php echo esc_html($a['name']); ?></td>
-                            <td><?php echo esc_html($slug); ?></td>
+                            <td>
+                                <input type="text" class="oa-slug-field" readonly value="[openai_assistant slug=&quot;<?php echo esc_attr($slug); ?>&quot;]" />
+                                <button type="button" class="button oa-copy-slug" data-slug="[openai_assistant slug=&quot;<?php echo esc_attr($slug); ?>&quot;]"><span class="dashicons dashicons-clipboard"></span></button>
+                            </td>
                             <td><?php echo esc_html($a['assistant_id']); ?></td>
                             <td>
                                 <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline;">
@@ -128,6 +131,7 @@ class OA_Assistant_Plugin {
     public function enqueue_admin_assets($hook) {
         if ($hook !== 'toplevel_page_oa-assistant') return;
         wp_enqueue_style('oa-admin-css', plugin_dir_url(__FILE__).'css/assistant.css', [], '3');
+        wp_enqueue_style('dashicons');
         wp_enqueue_script('oa-admin-js', plugin_dir_url(__FILE__).'js/assistant.js', ['jquery'], '3', true);
         wp_localize_script('oa-admin-js', 'oaAssistant', [
             'ajax_url' => admin_url('admin-ajax.php'),


### PR DESCRIPTION
## Summary
- make slug auto-generate from the name field
- show shortcode for each assistant in the admin table with a copy button
- enqueue dashicons for the copy button
- add styles for slug field and copy button

## Testing
- `php -l openai-assistant.php`

------
https://chatgpt.com/codex/tasks/task_e_6886d12582448332acee21afaad67bc7