### PR TITLE
Enable AMP without iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ with ChatGPT when troubleshooting.
 - `css/assistant.css` – plugin styles.
 - `js/assistant.js` – admin scripts (add/remove assistants).
 - `js/assistant-frontend.js` – frontend scripts.
+- `js/assistant-amp.js` – AMP-compatible frontend script.
 
 ## AMP/mobile support
 
-The plugin no longer embeds the chat in an `amp-iframe`. When the shortcode is
-rendered on an AMP page, the assistant output is skipped and a notice is
-displayed instead. If you need to use the shortcode, disable the AMP version of
-that page so the normal responsive layout loads. This ensures the chat works
-correctly on mobile devices.
+When a page is served in AMP mode, the shortcode wraps the chat interface in an
+`amp-script` element that loads a lightweight JavaScript file. This allows the
+assistant to work directly on AMP pages without relying on iframes.

--- a/js/assistant-amp.js
+++ b/js/assistant-amp.js
@@ -1,0 +1,44 @@
+(function(){
+  const container = document.currentScript.closest('.oa-assistant-chat');
+  if(!container) return;
+  const slug  = container.getAttribute('data-slug');
+  const ajax  = container.getAttribute('data-ajax');
+  const nonce = container.getAttribute('data-nonce');
+  const messages = container.querySelector('.oa-messages');
+  const form = container.querySelector('.oa-form');
+  const input = form.querySelector('input[name="user_message"]');
+
+  function appendMessage(text, cls){
+    const div = document.createElement('div');
+    div.className = 'msg ' + cls;
+    div.textContent = text;
+    messages.appendChild(div);
+    messages.scrollTop = messages.scrollHeight;
+  }
+
+  async function sendMessage(text){
+    if(!text) return;
+    appendMessage(text, 'user');
+    input.value = '';
+    try {
+      const resp = await fetch(ajax, {
+        method:'POST',
+        headers:{'Content-Type':'application/x-www-form-urlencoded'},
+        body:new URLSearchParams({action:'oa_assistant_chat', nonce:nonce, slug:slug, message:text})
+      });
+      const data = await resp.json();
+      if(data.success){
+        appendMessage(data.data.reply, 'bot');
+      }else{
+        appendMessage(data.data, 'error');
+      }
+    } catch(e){
+      appendMessage('Error al enviar', 'error');
+    }
+  }
+
+  form.addEventListener('submit', function(ev){
+    ev.preventDefault();
+    sendMessage(input.value.trim());
+  });
+})();


### PR DESCRIPTION
## Summary
- add amp-script frontend for AMP pages
- allow `amp-script` tag via filter
- wrap AMP output in `amp-script` element
- document new approach in README

## Testing
- `php -l openai-assistant.php`


------
https://chatgpt.com/codex/tasks/task_e_6886daf9e2748332ac20c56d68b9aff8