### PR TITLE
Update assistant API header

### DIFF
--- a/openai-assistant.php
+++ b/openai-assistant.php
@@ -286,7 +286,7 @@ class OA_Assistant_Plugin {
 
         $headers = [
             'Authorization' => 'Bearer ' . $api_key,
-            'OpenAI-Beta'   => 'assistants=v1',
+            'OpenAI-Beta'   => 'assistants=v2',
             'Content-Type'  => 'application/json',
         ];
 
@@ -452,6 +452,7 @@ class OA_Assistant_Plugin {
         $response = wp_remote_get('https://api.openai.com/v1/assistants', [
             'headers' => [
                 'Authorization' => 'Bearer ' . $key,
+                'OpenAI-Beta'   => 'assistants=v2',
                 'Content-Type'  => 'application/json',
             ],
         ]);


### PR DESCRIPTION
## Summary
- use `assistants=v2` header when calling OpenAI API
- send same header in `list_assistants`

## Testing
- `php -l openai-assistant.php`

------
https://chatgpt.com/codex/tasks/task_e_6887462c7d9c8332b48e09b996a79f92