### PR TITLE
Support OPENAI_API_KEY constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ with ChatGPT when troubleshooting.
 When a page is served in AMP mode, the shortcode wraps the chat interface in an
 `amp-script` element that loads a lightweight JavaScript file. This allows the
 assistant to work directly on AMP pages without relying on iframes.
+
+## API Key storage
+
+For improved security, you can define a constant in `wp-config.php`:
+
+```php
+define('OPENAI_API_KEY', 'your-secret-key');
+```
+
+When this constant exists, the plugin will use it instead of the value stored in
+the WordPress options table.


### PR DESCRIPTION
## Summary
- allow defining `OPENAI_API_KEY` in wp-config.php
- hide the API key field when the constant is present
- use constant value in API requests
- update documentation

## Testing
- `php -l openai-assistant.php`

------
https://chatgpt.com/codex/tasks/task_e_688c71a86940833289d3dbd35d21dfc6