### PR TITLE
Persist thread id in localStorage

### DIFF
--- a/js/assistant-amp.js
+++ b/js/assistant-amp.js
@@ -4,6 +4,8 @@
   const slug  = container.getAttribute('data-slug');
   const ajax  = container.getAttribute('data-ajax');
   const nonce = container.getAttribute('data-nonce');
+  const threadKey = 'oa_thread_' + slug;
+  let threadId = localStorage.getItem(threadKey);
   const messages = container.querySelector('.oa-messages');
   const form = container.querySelector('.oa-form');
   const input = form.querySelector('input[name="user_message"]');
@@ -33,10 +35,14 @@
       const resp = await fetch(ajax, {
         method:'POST',
         headers:{'Content-Type':'application/x-www-form-urlencoded'},
-        body:new URLSearchParams({action:'oa_assistant_chat', nonce:nonce, slug:slug, message:text})
+        body:new URLSearchParams({action:'oa_assistant_chat', nonce:nonce, slug:slug, message:text, thread_id:threadId||''})
       });
       const data = await resp.json();
       if(data.success){
+        if(data.data.thread_id){
+          threadId = data.data.thread_id;
+          localStorage.setItem(threadKey, threadId);
+        }
         appendMessage(data.data.reply, 'bot');
       }else{
         appendMessage(data.data, 'error');

--- a/js/assistant-frontend.js
+++ b/js/assistant-frontend.js
@@ -7,7 +7,9 @@ jQuery(function($){
         debug=w.data('debug')==1,
         msgs=w.find('.oa-messages'),
         debugLog=w.find('.oa-debug-log'),
-        input=w.find('input[name="user_message"]');
+        input=w.find('input[name="user_message"]'),
+        threadKey='oa_thread_'+slug,
+        threadId=localStorage.getItem(threadKey);
     function scrollToBottom(){ msgs[0].scrollTop = msgs[0].scrollHeight; }
     function sendMessage(text){
       if(!text) return;
@@ -19,9 +21,14 @@ jQuery(function($){
         action:'oa_assistant_chat',
         nonce:nonce,
         slug:slug,
-        message:text
+        message:text,
+        thread_id:threadId||''
       }).done(function(res){
         loader.remove();
+        if(res.success && res.data.thread_id){
+          threadId=res.data.thread_id;
+          localStorage.setItem(threadKey,threadId);
+        }
         msgs.append('<div class="msg bot">'+(res.success?res.data.reply:res.data)+'</div>');
         if(debug && res.success && res.data.debug){
           debugLog.text(debugLog.text()+res.data.debug+'\n');

--- a/openai-assistant.php
+++ b/openai-assistant.php
@@ -329,6 +329,11 @@ class OA_Assistant_Plugin {
             'Content-Type'  => 'application/json',
         ];
 
+        $posted_thread_id = sanitize_text_field($_POST['thread_id'] ?? '');
+        if ($posted_thread_id) {
+            $_SESSION['openai_thread_id'] = $posted_thread_id;
+        }
+
         if (empty($_SESSION['openai_thread_id'])) {
             $thread = wp_remote_post('https://api.openai.com/v1/threads', [
                 'headers' => $headers,
@@ -425,7 +430,7 @@ class OA_Assistant_Plugin {
             $this->json_error('Sin respuesta del assistant');
         }
 
-        $this->json_success(['reply' => $reply]);
+        $this->json_success(['reply' => $reply, 'thread_id' => $thread_id]);
     }
 
     public function ajax_send_key() {


### PR DESCRIPTION
## Summary
- persist assistant thread ID on the client side using localStorage
- accept `thread_id` from the client and include it in responses

## Testing
- `php -l openai-assistant.php`

------
https://chatgpt.com/codex/tasks/task_e_688c72805c9883329971c49674a1e89e