### PR TITLE
Fix Markdown output

### DIFF
--- a/css/assistant.css
+++ b/css/assistant.css
@@ -2,7 +2,7 @@
 .oa-messages{height:200px;overflow-y:auto;margin-bottom:10px;}
 .oa-debug-log{height:100px;overflow-y:auto;margin-bottom:10px;border:1px dashed #ccc;padding:5px;font-size:12px;white-space:pre-wrap;}
 .msg.user,
-.msg.bot{display:inline-block;padding:6px 10px;margin:4px 0;border-radius:12px;max-width:80%}
+.msg.bot{display:inline-block;padding:6px 10px;margin:4px 0;border-radius:12px;max-width:80%;white-space:pre-wrap}
 .msg.user{text-align:right;background:#e6e7e8}
 .msg.bot{text-align:left;background:#f4f4f4}
 .msg.loading{text-align:center;}

--- a/js/assistant-amp.js
+++ b/js/assistant-amp.js
@@ -11,10 +11,22 @@
   const form = container.querySelector('.oa-form');
   const input = form.querySelector('input[name="user_message"]');
 
+  function renderMarkdown(t){
+    let h = t.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    h = h.replace(/^### (.*)$/gm,'<h3>$1</h3>');
+    h = h.replace(/^## (.*)$/gm,'<h2>$1</h2>');
+    h = h.replace(/^# (.*)$/gm,'<h1>$1</h1>');
+    h = h.replace(/\*\*([^*]+)\*\*/g,'<strong>$1</strong>');
+    h = h.replace(/\*([^*]+)\*/g,'<em>$1</em>');
+    h = h.replace(/(?:\r\n|\n|\r)/g,'<br>');
+    return h;
+  }
+
   function appendMessage(text, cls){
     const div = document.createElement('div');
     div.className = 'msg ' + cls;
-    div.textContent = text;
+    if(cls === 'bot') div.innerHTML = renderMarkdown(text);
+    else div.textContent = text;
     messages.appendChild(div);
     messages.scrollTop = messages.scrollHeight;
   }
@@ -55,7 +67,7 @@
             try{
               const obj = JSON.parse(l.slice(6));
               const delta = obj.data && obj.data.delta && obj.data.delta.content ? obj.data.delta.content[0].text.value : (obj.delta && obj.delta.content ? obj.delta.content[0].text.value : '');
-              if(delta){ full += delta; loader.textContent = full; }
+              if(delta){ full += delta; loader.innerHTML = renderMarkdown(full); }
               if(obj.data && obj.data.id){
                 threadId = obj.data.thread_id || threadId;
                 if(threadId) localStorage.setItem(threadKey, threadId);

--- a/js/assistant-frontend.js
+++ b/js/assistant-frontend.js
@@ -11,6 +11,17 @@ jQuery(function($){
         threadKey='oa_thread_'+slug,
         threadId=localStorage.getItem(threadKey);
     if(threadId==='null' || threadId==='undefined'){ threadId=null; localStorage.removeItem(threadKey); }
+
+    function renderMarkdown(t){
+      var h=t.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+      h=h.replace(/^### (.*)$/gm,'<h3>$1</h3>');
+      h=h.replace(/^## (.*)$/gm,'<h2>$1</h2>');
+      h=h.replace(/^# (.*)$/gm,'<h1>$1</h1>');
+      h=h.replace(/\*\*([^*]+)\*\*/g,'<strong>$1</strong>');
+      h=h.replace(/\*([^*]+)\*/g,'<em>$1</em>');
+      h=h.replace(/(?:\r\n|\r|\n)/g,'<br>');
+      return h;
+    }
     function scrollToBottom(){ msgs[0].scrollTop = msgs[0].scrollHeight; }
     function sendMessage(text){
       if(!text) return;
@@ -33,7 +44,7 @@ jQuery(function($){
               if(threadId) localStorage.setItem(threadKey, threadId);
               else localStorage.removeItem(threadKey);
               loader.remove();
-              msgs.append('<div class="msg bot">'+full+'</div>');
+              msgs.append('<div class="msg bot">'+renderMarkdown(full)+'</div>');
               scrollToBottom();
               return;
             }
@@ -47,7 +58,7 @@ jQuery(function($){
                 try{
                   var obj=JSON.parse(line.slice(6));
                   var delta=obj.data&&obj.data.delta&&obj.data.delta.content?obj.data.delta.content[0].text.value:(obj.delta&&obj.delta.content?obj.delta.content[0].text.value:'');
-                  if(delta){ full+=delta; loader.text(full); }
+                  if(delta){ full+=delta; loader.html(renderMarkdown(full)); }
                   if(obj.data&&obj.data.id){
                     threadId=obj.data.thread_id||threadId;
                     if(threadId) localStorage.setItem(threadKey, threadId);


### PR DESCRIPTION
## Summary
- render assistant replies as Markdown in frontend/AMP scripts
- preserve line breaks in message bubbles

## Testing
- `php -l openai-assistant.php`

------
https://chatgpt.com/codex/tasks/task_e_688c804d0ca08332a5cc5f97a8e7631a