### PR TITLE
Make assistant chat responsive to container

### DIFF
--- a/css/assistant.css
+++ b/css/assistant.css
@@ -1,5 +1,5 @@
-.oa-assistant-chat{border:1px solid #ddd;padding:10px;max-width:400px;width:100%;box-sizing:border-box;}
-.oa-messages{height:200px;overflow-y:auto;margin-bottom:10px;}
+.oa-assistant-chat{border:1px solid #ddd;padding:10px;width:100%;height:100%;box-sizing:border-box;display:flex;flex-direction:column;}
+.oa-messages{flex:1 1 auto;overflow-y:auto;margin-bottom:10px;}
 .oa-debug-log{height:100px;overflow-y:auto;margin-bottom:10px;border:1px dashed #ccc;padding:5px;font-size:12px;white-space:pre-wrap;}
 .msg.user,
 .msg.bot{display:inline-block;padding:6px 10px;margin:4px 0;border-radius:12px;max-width:80%;white-space:pre-wrap}


### PR DESCRIPTION
## Summary
- Remove fixed sizing from `.oa-assistant-chat` and `.oa-messages`
- Use flex layout so chat fills 100% of its container

## Testing
- `npm test` *(fails: package.json missing)*
- `php -l openai-assistant.php`


------
https://chatgpt.com/codex/tasks/task_e_688db9afa03c8332a03690719757a2d8