### PR TITLE
Align chat bubbles vertically

### DIFF
--- a/css/assistant.css
+++ b/css/assistant.css
@@ -1,10 +1,10 @@
 .oa-assistant-chat{border:1px solid #ddd;padding:10px;width:100%;height:100%;box-sizing:border-box;display:flex;flex-direction:column;}
-.oa-messages{flex:1 1 auto;overflow-y:auto;margin-bottom:10px;}
+.oa-messages{flex:1 1 auto;overflow-y:auto;margin-bottom:10px;display:flex;flex-direction:column;}
 .oa-debug-log{height:100px;overflow-y:auto;margin-bottom:10px;border:1px dashed #ccc;padding:5px;font-size:12px;white-space:pre-wrap;}
 .msg.user,
-.msg.bot{display:inline-block;padding:6px 10px;margin:4px 0;border-radius:12px;max-width:80%;white-space:pre-wrap}
-.msg.user{text-align:right;background:#e6e7e8}
-.msg.bot{text-align:left;background:#f4f4f4}
+.msg.bot{padding:6px 10px;margin:4px 0;border-radius:12px;max-width:80%;white-space:pre-wrap}
+.msg.user{align-self:flex-end;text-align:right;background:#e6e7e8}
+.msg.bot{align-self:flex-start;text-align:left;background:#f4f4f4}
 .msg.loading{text-align:center;}
 .msg.loading:after{content:"";display:inline-block;width:12px;height:12px;border:2px solid #999;border-right-color:transparent;border-radius:50%;animation:oa-spin 0.8s linear infinite;}
 @keyframes oa-spin{from{transform:rotate(0)}to{transform:rotate(360deg)}}


### PR DESCRIPTION
## Summary
- display chat messages in a vertical column
- right-align user messages and left-align bot replies

## Testing
- `php -l openai-assistant.php`
- `php -l openai-stream.php`


------
https://chatgpt.com/codex/tasks/task_e_688dbd28cdb4833292dfb8c198b5acc9