### PR TITLE
Fix streaming SSE handling for progressive updates

### DIFF
--- a/openai-stream.js
+++ b/openai-stream.js
@@ -5,9 +5,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const eventSource = new EventSource('/wp-admin/admin-ajax.php?action=stream_chat');
 
   eventSource.onmessage = function (event) {
-    const data = JSON.parse(event.data);
-    if (data.choices) {
-      output.innerHTML += data.choices[0].delta.content || '';
+    if (event.data === '[DONE]') {
+      eventSource.close();
+      return;
+    }
+    try {
+      const data = JSON.parse(event.data);
+      if (data.choices) {
+        output.innerHTML += (data.choices[0].delta && data.choices[0].delta.content) || '';
+      }
+    } catch (e) {
+      console.error('Error al parsear JSON del stream:', e, event.data);
     }
   };
 

--- a/openai-stream.php
+++ b/openai-stream.php
@@ -17,6 +17,11 @@ function openai_stream_chat() {
     header('Content-Type: text/event-stream');
     header('Cache-Control: no-cache');
     header('Connection: keep-alive');
+    header('X-Accel-Buffering: no');
+    while (ob_get_level()) {
+        ob_end_flush();
+    }
+    ob_implicit_flush(true);
 
     $api_key = defined('OPENAI_API_KEY') ? OPENAI_API_KEY : '';
 
@@ -36,7 +41,7 @@ function openai_stream_chat() {
             'stream' => true
         ]),
         CURLOPT_WRITEFUNCTION => function ($curl, $data) {
-            echo "data: $data\n\n";
+            echo $data;
             @ob_flush();
             flush();
             return strlen($data);


### PR DESCRIPTION
## Summary
- ensure PHP streaming endpoint outputs raw SSE chunks and flushes buffers
- handle `[DONE]` events and parse errors in stream consumer

## Testing
- `php -l openai-stream.php`
- `node --check openai-stream.js`


------
https://chatgpt.com/codex/tasks/task_e_688dc0de0be88332b6e1b2af233698eb